### PR TITLE
Change name of `customerAsid` and `providerAsid` to `customerAsn` and `providerAsn`

### DIFF
--- a/draft-ietf-sidrops-aspa-slurm.xml
+++ b/draft-ietf-sidrops-aspa-slurm.xml
@@ -138,11 +138,11 @@
     <section title="Validated ASPA Filters" anchor="aspaFilters">
       <t>
         The RP can configure zero or more Validated ASPA Filters ("ASPA Filters" for short).
-        Each ASPA Filter contains a single 'customerAsid' and optionally a single 'comment'.
+        Each ASPA Filter contains a single 'customerASID' and optionally a single 'comment'.
       </t>
       <ul>
-        <li>The 'customerAsid' member has as value a number.</li>
-        <li>It is RECOMMENDED that an explanatory comment is included with each ASPA Filter so that it can be shown to users of the RP software.</li>
+        <li>The 'customerASID' field contains the AS number of the Customer Autonomous System that is the authorizing entity.</li>
+        <li>It is RECOMMENDED that an explanatory comment be included with each ASPA Filter so that it can be shown to users of the RP software.</li>
       </ul>
       <t>
         Any Validated ASPA Payload (VAP) <xref target="I-D.ietf-sidrops-aspa-profile"/> that matches any configured ASPA Filter MUST be removed from the RP's output.
@@ -160,7 +160,7 @@
 <![CDATA[
 "aspaFilter": [
   {
-    "customerAsid": 64496,
+    "customerASID": 64496,
     "comment": "Filter out ASPA Payloads which specify AS 64496 as the Customer ASID"
   }
 ]
@@ -172,17 +172,25 @@
     <section title="Locally Added ASPA Assertions" anchor="aspaAssertions">
       <t>
         Each RP is locally configured with a (possibly empty) array of ASPA Assertions.
-        Each ASPA Assertion MUST contain a 'customerAsid' member containing the Customer ASID and a 'providerSet' array of numbers, reflecting the set of Provider ASNs.
-        It is RECOMMENDED that an explanatory comment is also included so that it can be shown to users of the RP software.
+        Each ASPA Assertion MUST contain a 'customerASID' member containing the Customer ASID and a 'providerSet' array of numbers, reflecting the set of Provider ASNs.
+        It is RECOMMENDED that an explanatory comment be included that may be shown to users of the RP software.
       </t>
       <t>
         The above is expressed as a value of the "aspaAssertions" member, as an array of zero or more objects.
         Each object MUST contain one each of all of the following members:
       </t>
       <ul>
-        <li>An "customerAsid" member whose value is a number.</li>
+        <li>A "customerASID" member whose value is a number.</li>
         <li>A "providerSet" member whose value is an array of numbers.</li>
         <li>An optional "comment" member whose value is a string.</li>
+      </ul>
+      <t>
+        In addition to the constraints described by the formal ASN.1 definition, the contents of the providerSet field MUST satisfy the following constraints:
+      </t>
+      <ul>
+        <li>The customerASID value MUST NOT appear in any ASID in the providerSet field.</li>
+        <li>The elements of providerSet MUST be ordered in ascending numerical order.</li>
+        <li>Each value of ASID MUST be unique (with respect to the other elements of providers).</li>
       </ul>
       <t>
         The following example JSON structure represents a "aspaAssertions" member with one object as described above:
@@ -191,7 +199,7 @@
 <![CDATA[
 "aspaAssertions": [
   {
-    "customerAsid": 64496,
+    "customerASID": 64496,
     "providerSet": [64497, 64498],
     "comment": "Locally assert 64497 are 64498 are providers to 64496"
   }
@@ -246,7 +254,7 @@
     ],
     "aspaFilters": [
       {
-        "customerAsid": 64496,
+        "customerASID": 64496,
         "comment": "ASPAs matching Customer ASID 64496"
       }
     ]
@@ -275,7 +283,7 @@
     ],
     "aspaAssertions": [
       {
-        "customerAsid": 64496,
+        "customerASID": 64496,
         "providerSet": [64497, 64498],
         "comment": "Locally assert 64497 and 64498 are providers for 64496"
       }

--- a/draft-ietf-sidrops-aspa-slurm.xml
+++ b/draft-ietf-sidrops-aspa-slurm.xml
@@ -138,10 +138,10 @@
     <section title="Validated ASPA Filters" anchor="aspaFilters">
       <t>
         The RP can configure zero or more Validated ASPA Filters ("ASPA Filters" for short).
-        Each ASPA Filter contains a single 'customerASID' and optionally a single 'comment'.
+        Each ASPA Filter contains a single 'customerAsn' and optionally a single 'comment'.
       </t>
       <ul>
-        <li>The 'customerASID' field contains the AS number of the Customer Autonomous System that is the authorizing entity.</li>
+        <li>The 'customerAsn' field contains the AS number of the Customer Autonomous System that is the authorizing entity.</li>
         <li>It is RECOMMENDED that an explanatory comment be included with each ASPA Filter so that it can be shown to users of the RP software.</li>
       </ul>
       <t>
@@ -151,7 +151,7 @@
         A VAP is considered to match with an ASPA Filter if the following condition applies:
       </t>
       <ol>
-        <li>The VAP is considered to match if the VAP Customer ASID is equal to the ASPA Filter Customer ASID.</li>
+        <li>The VAP is considered to match if the VAP Customer ASN is equal to the ASPA Filter Customer ASN.</li>
       </ol>
       <t>
         The following example JSON structure represents a "aspaFilters" member with one object as described above:
@@ -160,8 +160,8 @@
 <![CDATA[
 "aspaFilter": [
   {
-    "customerASID": 64496,
-    "comment": "Filter out ASPA Payloads which specify AS 64496 as the Customer ASID"
+    "customerAsn": 64496,
+    "comment": "Filter out ASPA Payloads which specify AS 64496 as the Customer Asn"
   }
 ]
 ]]>
@@ -172,7 +172,7 @@
     <section title="Locally Added ASPA Assertions" anchor="aspaAssertions">
       <t>
         Each RP is locally configured with a (possibly empty) array of ASPA Assertions.
-        Each ASPA Assertion MUST contain a 'customerASID' member containing the Customer ASID and a 'providerSet' array of numbers, reflecting the set of Provider ASNs.
+        Each ASPA Assertion MUST contain a 'customerAsn' member containing the Customer ASN and a 'providerAsns' array of numbers, reflecting the set of Provider ASNs.
         It is RECOMMENDED that an explanatory comment be included that may be shown to users of the RP software.
       </t>
       <t>
@@ -180,17 +180,17 @@
         Each object MUST contain one each of all of the following members:
       </t>
       <ul>
-        <li>A "customerASID" member whose value is a number.</li>
-        <li>A "providerSet" member whose value is an array of numbers.</li>
+        <li>A "customerAsn" member whose value is a number.</li>
+        <li>A "providerAsns" member whose value is an array of numbers.</li>
         <li>An optional "comment" member whose value is a string.</li>
       </ul>
       <t>
-        In addition to the constraints described by the formal ASN.1 definition, the contents of the providerSet field MUST satisfy the following constraints:
+        In addition to the constraints described by the formal ASN.1 definition, the contents of the providerAsns field MUST satisfy the following constraints:
       </t>
       <ul>
-        <li>The customerASID value MUST NOT appear in any ASID in the providerSet field.</li>
-        <li>The elements of providerSet MUST be ordered in ascending numerical order.</li>
-        <li>Each value of ASID MUST be unique (with respect to the other elements of providers).</li>
+        <li>The customerAsn value MUST NOT appear in any ASN in the providerAsns field.</li>
+        <li>The elements of providerAsns MUST be ordered in ascending numerical order.</li>
+        <li>Each value of ASN MUST be unique (with respect to the other elements of providers).</li>
       </ul>
       <t>
         The following example JSON structure represents a "aspaAssertions" member with one object as described above:
@@ -199,7 +199,7 @@
 <![CDATA[
 "aspaAssertions": [
   {
-    "customerASID": 64496,
+    "customerAsn": 64496,
     "providerSet": [64497, 64498],
     "comment": "Locally assert 64497 are 64498 are providers to 64496"
   }
@@ -254,8 +254,8 @@
     ],
     "aspaFilters": [
       {
-        "customerASID": 64496,
-        "comment": "ASPAs matching Customer ASID 64496"
+        "customerAsn": 64496,
+        "comment": "ASPAs matching Customer ASN 64496"
       }
     ]
   },
@@ -283,7 +283,7 @@
     ],
     "aspaAssertions": [
       {
-        "customerASID": 64496,
+        "customerAsn": 64496,
         "providerSet": [64497, 64498],
         "comment": "Locally assert 64497 and 64498 are providers for 64496"
       }


### PR DESCRIPTION
SLURM v1 defines prefixFilters, bgpsecFilters, prefixAssertions, and bgpsecAssertions. All of these have an (optional) member "asn" [[RFC 8416](https://datatracker.ietf.org/doc/html/rfc6482)], e.g.: 
```
           "bgpsecFilters": [
             {
               "asn": 64496,
               "comment": "All keys for ASN"
             },
```

This, even though the ROA profile [[RFC 6482](https://datatracker.ietf.org/doc/html/rfc6482)] refers to them as asID (or ASID).

The latest draft of the ASPA profile [[draft-ietf-sidrops-aspa-profile-19](https://www.ietf.org/archive/id/draft-ietf-sidrops-aspa-profile-19.html)] defines a `customerASID` and `providers` (which is a sequence of `ASID`). 

Currently, the SLURM v2 draft copies that wording from the profile, e.g.:

```
    "aspaAssertions": [
      {
        "customerAsid": 64496,
        "providerSet": [64497, 64498],
        "comment": "Locally assert 64497 and 64498 are providers for 64496"
      }
```

I believe that for consistency sake it would be worthwhile to follow the naming scheme as started by SLURM v1 for ROAs, and use `customerAsn` rather than `customerAsid`. I do not expect most (or any) operators to read the ROA or ASPA profile RFC, but I would expect them to write their own SLURM file. Even though I expect most operators to be aware that `asid` and `asn` refer to the same thing (though I did look up whether they actually were the same), using both in the same file can lead to accidental typos and, in my opinion, unnecessary friction.

What is used for providers seems to vary. I have no strong opinion on using `providerSet`, although I have had to look up whether it was `provider*s*Set` or `providerSet`, so perhaps a name like `providers` or `providerAsns` might be simpler.